### PR TITLE
Adds parallelism to test execution

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,10 @@
 log_level = DEBUG
 log_file = tests/.pytest.log
 log_file_level = DEBUG
+
+# Sets the parallelism of the tests that are curretnly running.
+addopts = -nauto
+
 # Skip `charm` tests since it slows down the CI
 # Skip benchmark since that is meant to be run locally only
 norecursedirs = charm benchmark

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ TESTS_REQUIRES = [
     'pytest-mock',
     'pytest-cov',
     'pytest-env',
+    'pytest-sugar',
+    'pytest-xdist',
     'pytest-benchmark',
     'pytest-benchmark[histogram]',
     'pyyaml',


### PR DESCRIPTION
Not sure if this will create any issues with how travis works or when running stuff on AWS / benchmark testing, but this makes it so that when you run `docker-compose run --rm honeybadgermpc` it cuts about a minute off of the tests running.